### PR TITLE
Android: ensure base class update function is called on update, and use direct prop setting

### DIFF
--- a/android/src/main/java/com/reactnativeklarnaonsitemessaging/KlarnaOnsiteMessagingLayout.kt
+++ b/android/src/main/java/com/reactnativeklarnaonsitemessaging/KlarnaOnsiteMessagingLayout.kt
@@ -9,7 +9,7 @@ class KlarnaOnsiteMessagingLayout(
   private val reactContext: ThemedReactContext,
   private val eventEmitter: KlarnaOnsiteMessagingEventEmitter
 ): LinearLayout(reactContext) {
-  private val osmView: KlarnaOSMView
+  val osmView: KlarnaOSMView
 
   init {
     inflate(context, R.layout.klarna_onsite_messaging_layout, this)
@@ -18,22 +18,8 @@ class KlarnaOnsiteMessagingLayout(
     osmView.hostActivity = reactContext.currentActivity
   }
 
-  var clientId: String = ""
-  var placementKey: String = ""
-  var locale: String = ""
-  var region: Int = 0
-  var environment: Int = 0
-  var purchaseAmount: Int? = null
-
   fun setupOSMView() {
-    osmView.clientId = clientId
-    osmView.placementKey = placementKey
-    osmView.locale = locale
-    osmView.environment = KlarnaOSMEnvironment::class.fromRawValue(environment)
-    osmView.region = KlarnaOSMRegion::class.fromRawValue(region)
-    osmView.purchaseAmount = purchaseAmount?.toLong()
     osmView.hostActivity = reactContext.currentActivity
-
     osmView.render(RenderResult {
       if(it != null) {
         eventEmitter.onOSMError(it, id)

--- a/android/src/main/java/com/reactnativeklarnaonsitemessaging/KlarnaOnsiteMessagingViewManager.kt
+++ b/android/src/main/java/com/reactnativeklarnaonsitemessaging/KlarnaOnsiteMessagingViewManager.kt
@@ -3,52 +3,55 @@ package com.reactnativeklarnaonsitemessaging
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.klarna.mobile.sdk.api.osm.KlarnaOSMEnvironment
+import com.klarna.mobile.sdk.api.osm.KlarnaOSMRegion
 
 class KlarnaOnsiteMessagingViewManager : ViewGroupManager<KlarnaOnsiteMessagingLayout>() {
 
   @ReactProp(name = "clientId")
   fun setClientId(view: KlarnaOnsiteMessagingLayout, clientId: String) {
     with(view) {
-      this.clientId = clientId
+      this.osmView.clientId = clientId
     }
   }
 
   @ReactProp(name = "placementKey")
   fun setPlacementKey(view: KlarnaOnsiteMessagingLayout, placementKey: String) {
     with(view) {
-      this.placementKey = placementKey
+      this.osmView.placementKey = placementKey
     }
   }
 
   @ReactProp(name = "locale")
   fun setLocale(view: KlarnaOnsiteMessagingLayout, locale: String) {
     with(view) {
-      this.locale = locale
+      this.osmView.locale = locale
     }
   }
 
   @ReactProp(name = "environment")
   fun setEnvironment(view: KlarnaOnsiteMessagingLayout, environment: Int) {
     with(view) {
-      this.environment = environment
+      this.osmView.environment = KlarnaOSMEnvironment::class.fromRawValue(environment)
     }
   }
 
   @ReactProp(name = "region")
   fun setRegion(view: KlarnaOnsiteMessagingLayout, region: Int) {
     with(view) {
-      this.region = region
+      this.osmView.region = KlarnaOSMRegion::class.fromRawValue(region)
     }
   }
 
   @ReactProp(name = "purchaseAmount")
   fun setPurchaseAmount(view: KlarnaOnsiteMessagingLayout, purchaseAmount: Int?) {
     with(view) {
-      this.purchaseAmount = purchaseAmount
+      this.osmView.purchaseAmount = purchaseAmount?.toLong()
     }
   }
 
   override fun onAfterUpdateTransaction(view: KlarnaOnsiteMessagingLayout) {
+    super.onAfterUpdateTransaction(view)
     view.setupOSMView()
   }
 


### PR DESCRIPTION
* Ensures base class update function is always called as per recommendation of rn docs
* directly set `osmView` values on prop update instead of using intermediary values 