### PR TITLE
chore: Upgrade SDK to 2.2.2/2.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.5.4'
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
@@ -133,5 +133,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.klarna.mobile:sdk:2.2.2'
+  implementation 'com.klarna.mobile:sdk:2.2.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,5 +133,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.klarna.mobile:sdk:2.0.39'
+  implementation 'com.klarna.mobile:sdk:2.2.2'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spo-cmoore/react-native-klarna-onsite-messaging",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Klarna On-Site Messaging SDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-klarna-onsite-messaging.podspec
+++ b/react-native-klarna-onsite-messaging.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "KlarnaMobileSDK", "~> 2.0.36"
+  s.dependency "KlarnaMobileSDK", "~> 2.2.2"
 end


### PR DESCRIPTION
## iOS

* Bump SDK to 2.2.2 for bug fixes

## Android

* Bump SDK to 2.2.0 for bug fixes
* Bump gradle version to support newer gradle features used in upgraded SDK package.